### PR TITLE
Remove Dangling '</h5>' In Post Titles For Front Page

### DIFF
--- a/_includes/postlist.html
+++ b/_includes/postlist.html
@@ -2,7 +2,7 @@
  <ul>
   {% for post in site.posts limit 5 %}
     <li>
-        <a href="{{ post.url }}" class="title"><span class="date">{{ post.date  | date: '%b %-d' }} </span>{{ post.title }}</a></h5>
+        <a href="{{ post.url }}" class="title"><span class="date">{{ post.date  | date: '%b %-d' }} </span>{{ post.title }}</a>
         <div class="excerpt">
           {{ post.excerpt }}
         </div>


### PR DESCRIPTION
Fixes Issue #2